### PR TITLE
chore: merge dev into main

### DIFF
--- a/.github/workflows/build-executables.yml
+++ b/.github/workflows/build-executables.yml
@@ -63,7 +63,11 @@ jobs:
       - name: List built files
         run: |
           echo "Files in dist-executable:"
-          dir dist-executable || echo "No dist-executable directory found"
+          if (Test-Path dist-executable) {
+            dir dist-executable
+          } else {
+            echo "No dist-executable directory found"
+          }
 
       - name: Upload Windows artifacts to release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
This PR merges the latest changes from the `dev` branch into `main`.

## Changes included
- fix: handle missing dist-executable directory in Windows build workflow (#9)
- Previous syncs from main to dev

## Purpose
This merge brings the latest development work, including bug fixes and improvements, into the main branch.