### PR TITLE
fix: disable electron-builder auto-publish to github

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,8 @@
     },
     "linux": {
       "target": "AppImage"
-    }
+    },
+    "publish": "never"
   },
   "pnpm": {
     "onlyBuiltDependencies": [


### PR DESCRIPTION
## Summary

- Adds `"publish": "never"` to `package.json` `build` config
- Prevents `electron-builder` from trying to publish artifacts to GitHub (it detects git tags and attempts auto-publish, failing because `GH_TOKEN` is not set in the build environment)
- The CI workflow already handles artifact upload via `softprops/action-gh-release`

## Test plan

- [x] 56 tests passing
- [x] Lint clean

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)