### PR TITLE
fix: pass --publish never flag to electron-builder cli

### DIFF
--- a/build-executable.js
+++ b/build-executable.js
@@ -82,7 +82,7 @@ buildGuiProcess.on('close', (guiCode) => {
     
     console.log('\n🔨 Building executable with electron-builder...');
     // Use shell: true to ensure pnpm is found in PATH (especially on Windows in CI)
-    const buildProcess = spawn('pnpm', ['exec', 'electron-builder'], {
+    const buildProcess = spawn('pnpm', ['exec', 'electron-builder', '--publish', 'never'], {
         stdio: 'inherit',
         cwd: process.cwd(),
         shell: true

--- a/package.json
+++ b/package.json
@@ -97,8 +97,7 @@
     },
     "linux": {
       "target": "AppImage"
-    },
-    "publish": "never"
+    }
   },
   "pnpm": {
     "onlyBuiltDependencies": [


### PR DESCRIPTION
## Summary

- Removes `"publish": "never"` from `package.json` build config — this was wrong syntax that made electron-builder look for a module named `electron-publisher-never`
- Adds `--publish never` CLI flags to the `electron-builder` spawn in `build-executable.js` — this correctly sets `PublishPolicy` to never without requiring a publisher module

## Test plan

- [x] 56 tests passing
- [x] Lint clean

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)