### PR TITLE
fix: detect vol. and japanese bracket series title formats

### DIFF
--- a/src/core/SeriesDetector.ts
+++ b/src/core/SeriesDetector.ts
@@ -52,6 +52,27 @@ export class SeriesDetector {
       }
     }
 
+    // Pattern 6: "Japanese Title N [Romanized Title N]" - manga with bracketed romanized titles
+    // e.g. "葬送のフリーレン 9 [Sōsō no Frieren 9]" -> series: "Sōsō no Frieren", book: 9
+    const pattern6 = title.match(/^.+\s+(\d+(?:\.\d+)?)\s+\[(.+?)\s+\1\]$/);
+    if (pattern6) {
+      return {
+        seriesName: pattern6[2].trim(),
+        bookNumber: parseFloat(pattern6[1]),
+      };
+    }
+
+    // Pattern 7: "Series Title, Vol. N" or "Series Title Vol. N" with optional trailing parens
+    // e.g. "Frieren: Beyond Journey's End, Vol. 7" -> series: "Frieren: Beyond Journey's End", book: 7
+    // Must come before Pattern 5 (colon) so full series name is captured, not just prefix
+    const pattern7 = title.match(/^(.+?),?\s+(?:vol(?:ume)?\.?\s*)(\d+(?:\.\d+)?)(?:\s*\(.+\))?$/i);
+    if (pattern7) {
+      return {
+        seriesName: pattern7[1].trim(),
+        bookNumber: parseFloat(pattern7[2]),
+      };
+    }
+
     // Pattern 5: "Series Name: Book Title"
     const pattern5 = title.match(/^(.+?):\s*(.+)/);
     if (pattern5) {

--- a/tests/unit/SeriesDetector.test.ts
+++ b/tests/unit/SeriesDetector.test.ts
@@ -58,6 +58,36 @@ describe('SeriesDetector', () => {
 
       expect(result.seriesName).toBeNull();
     });
+
+    it('should extract series info from Vol. format: "Series Title, Vol. N"', () => {
+      const result = SeriesDetector.extractSeriesInfo("Frieren: Beyond Journey's End, Vol. 7");
+
+      expect(result.seriesName).toBe("Frieren: Beyond Journey's End");
+      expect(result.bookNumber).toBe(7);
+    });
+
+    it('should extract series info from Vol. format with trailing parenthetical', () => {
+      const result = SeriesDetector.extractSeriesInfo(
+        'Pretty Guardian Sailor Moon, Vol. 1 (Naoko Takeuchi Collection)',
+      );
+
+      expect(result.seriesName).toBe('Pretty Guardian Sailor Moon');
+      expect(result.bookNumber).toBe(1);
+    });
+
+    it('should extract series info from Japanese bracket format: "Title N [Romanized N]"', () => {
+      const result = SeriesDetector.extractSeriesInfo('葬送のフリーレン 9 [Sōsō no Frieren 9]');
+
+      expect(result.seriesName).toBe('Sōsō no Frieren');
+      expect(result.bookNumber).toBe(9);
+    });
+
+    it('should extract series info from Japanese bracket format with multi-digit number', () => {
+      const result = SeriesDetector.extractSeriesInfo('葬送のフリーレン 15 [Sōsō no Frieren 15]');
+
+      expect(result.seriesName).toBe('Sōsō no Frieren');
+      expect(result.bookNumber).toBe(15);
+    });
   });
 
   describe('normalizeAuthor', () => {


### PR DESCRIPTION
## Summary

- **Pattern 6** (Japanese bracket): `"葬送のフリーレン 9 [Sōsō no Frieren 9]"` → series: `"Sōsō no Frieren"`, book: 9
- **Pattern 7** (Vol. format): `"Frieren: Beyond Journey's End, Vol. 7"` → series: `"Frieren: Beyond Journey's End"`, book: 7; inserted before colon pattern so full series name is captured, not just the prefix
- Also handles trailing parentheticals: `"Pretty Guardian Sailor Moon, Vol. 1 (Naoko Takeuchi Collection)"` → series: `"Pretty Guardian Sailor Moon"`, book: 1

## Test plan

- [x] 60 tests passing (4 new)
- [x] TypeScript clean
- [x] Verified against real GoodReads CSV export — all Frieren entries now correctly detected

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)