### PR TITLE
fix: skip cjk bracket-format titles from series tracking

### DIFF
--- a/src/core/SeriesDetector.ts
+++ b/src/core/SeriesDetector.ts
@@ -58,7 +58,9 @@ export class SeriesDetector {
     // would otherwise pollute the timeline and weighting of the English edition.
     const pattern6 = title.match(/^.+\s+(\d+(?:\.\d+)?)\s+\[(.+?)\s+\1\]$/);
     if (pattern6) {
-      const hasCJK = /[぀-ヿ㐀-䶿一-鿿豈-﫿ｦ-ﾟ]/.test(title);
+      const hasCJK = /[\u3040-\u30FF\u3400-\u4DBF\u4E00-\u9FFF\uF900-\uFAFF\uFF66-\uFF9F]/.test(
+        title,
+      );
       if (hasCJK) {
         return { seriesName: null, bookNumber: undefined };
       }

--- a/src/core/SeriesDetector.ts
+++ b/src/core/SeriesDetector.ts
@@ -53,9 +53,15 @@ export class SeriesDetector {
     }
 
     // Pattern 6: "Japanese Title N [Romanized Title N]" - manga with bracketed romanized titles
-    // e.g. "葬送のフリーレン 9 [Sōsō no Frieren 9]" -> series: "Sōsō no Frieren", book: 9
+    // If the title contains CJK characters, skip series tracking entirely — GoodReads
+    // auto-adds foreign-language editions that users may not be able to read, and they
+    // would otherwise pollute the timeline and weighting of the English edition.
     const pattern6 = title.match(/^.+\s+(\d+(?:\.\d+)?)\s+\[(.+?)\s+\1\]$/);
     if (pattern6) {
+      const hasCJK = /[぀-ヿ㐀-䶿一-鿿豈-﫿ｦ-ﾟ]/.test(title);
+      if (hasCJK) {
+        return { seriesName: null, bookNumber: undefined };
+      }
       return {
         seriesName: pattern6[2].trim(),
         bookNumber: parseFloat(pattern6[1]),

--- a/src/services/SeriesProgressionTimelineService.ts
+++ b/src/services/SeriesProgressionTimelineService.ts
@@ -118,7 +118,7 @@ export class SeriesProgressionTimelineService {
     // series that is missing that volume number, add it as read. Applies only to "read"
     // shelf — to-read/reading-next CJK entries are intentionally ignored to avoid creating
     // phantom continuation books for foreign editions the user may not be tracking.
-    const CJK_RE = /[぀-ヿ㐀-䶿一-鿿豈-﫿ｦ-ﾟ]/;
+    const CJK_RE = /[\u3040-\u30FF\u3400-\u4DBF\u4E00-\u9FFF\uF900-\uFAFF\uFF66-\uFF9F]/;
     const BRACKET_VOL_RE = /^.+\s+(\d+(?:\.\d+)?)\s+\[.+?\s+\1\]$/;
 
     for (const book of allBooks) {
@@ -165,7 +165,7 @@ export class SeriesProgressionTimelineService {
 
     for (const book of allBooks) {
       // Skip CJK-titled books from unnumbered inference
-      if (/[぀-ヿ㐀-䶿一-鿿豈-﫿ｦ-ﾟ]/.test(book.Title)) {
+      if (CJK_RE.test(book.Title)) {
         continue;
       }
 
@@ -366,7 +366,7 @@ export class SeriesProgressionTimelineService {
 
             // Skip CJK-titled books — foreign-language auto-added editions should not
             // be inferred into an English series
-            if (/[぀-ヿ㐀-䶿一-鿿豈-﫿ｦ-ﾟ]/.test(book.Title)) {
+            if (CJK_RE.test(book.Title)) {
               return false;
             }
 

--- a/src/services/SeriesProgressionTimelineService.ts
+++ b/src/services/SeriesProgressionTimelineService.ts
@@ -113,6 +113,52 @@ export class SeriesProgressionTimelineService {
       }
     }
 
+    // Pass 1.5: CJK read reconciliation
+    // When a CJK bracket edition is "read" and the same author has exactly one English Vol.
+    // series that is missing that volume number, add it as read. Applies only to "read"
+    // shelf — to-read/reading-next CJK entries are intentionally ignored to avoid creating
+    // phantom continuation books for foreign editions the user may not be tracking.
+    const CJK_RE = /[぀-ヿ㐀-䶿一-鿿豈-﫿ｦ-ﾟ]/;
+    const BRACKET_VOL_RE = /^.+\s+(\d+(?:\.\d+)?)\s+\[.+?\s+\1\]$/;
+
+    for (const book of allBooks) {
+      if (!CJK_RE.test(book.Title)) continue;
+      if (book['Exclusive Shelf']?.trim().toLowerCase() !== ShelfType.READ) continue;
+
+      const bracketMatch = book.Title.match(BRACKET_VOL_RE);
+      if (!bracketMatch) continue;
+
+      const volNumber = parseFloat(bracketMatch[1]);
+      const normalizedAuthor = SeriesDetector.normalizeAuthor(book.Author);
+
+      // Find all series by this author
+      const authorSeries = [...seriesMap.values()].filter(
+        (s) => s.normalizedAuthor === normalizedAuthor,
+      );
+
+      // Only reconcile when there is exactly one series — avoids guessing which
+      // series the CJK volume belongs to when an author has multiple tracked series
+      if (authorSeries.length !== 1) continue;
+
+      const series = authorSeries[0];
+
+      // Only fill if the volume is genuinely missing
+      if (series.books.some((b) => b.bookNumber === volNumber)) continue;
+
+      const dateRead = book['Date Read'] ? new Date(book['Date Read']) : undefined;
+      series.books.push({
+        title: book.Title,
+        bookNumber: volNumber,
+        status: BookProgressStatus.READ,
+        dateRead,
+        author: book.Author,
+      });
+
+      if (volNumber > series.highestBookNumber) {
+        series.highestBookNumber = volNumber;
+      }
+    }
+
     // Second pass: handle books in series without explicit numbers
     // Collect unnumbered books for each series to infer their positions
     const unnumberedBooksBySeries = new Map<string, Array<{ book: Book; seriesName: string }>>();

--- a/src/services/SeriesProgressionTimelineService.ts
+++ b/src/services/SeriesProgressionTimelineService.ts
@@ -118,6 +118,11 @@ export class SeriesProgressionTimelineService {
     const unnumberedBooksBySeries = new Map<string, Array<{ book: Book; seriesName: string }>>();
 
     for (const book of allBooks) {
+      // Skip CJK-titled books from unnumbered inference
+      if (/[぀-ヿ㐀-䶿一-鿿豈-﫿ｦ-ﾟ]/.test(book.Title)) {
+        continue;
+      }
+
       const seriesInfo = SeriesDetector.extractSeriesInfo(book.Title);
 
       // Only process books that are in a series but don't have explicit numbers
@@ -310,6 +315,12 @@ export class SeriesProgressionTimelineService {
 
             // Must not already be in the series
             if (series.books.some((b) => b.title === book.Title)) {
+              return false;
+            }
+
+            // Skip CJK-titled books — foreign-language auto-added editions should not
+            // be inferred into an English series
+            if (/[぀-ヿ㐀-䶿一-鿿豈-﫿ｦ-ﾟ]/.test(book.Title)) {
               return false;
             }
 

--- a/tests/unit/SeriesDetector.test.ts
+++ b/tests/unit/SeriesDetector.test.ts
@@ -75,18 +75,18 @@ describe('SeriesDetector', () => {
       expect(result.bookNumber).toBe(1);
     });
 
-    it('should extract series info from Japanese bracket format: "Title N [Romanized N]"', () => {
+    it('should skip series tracking for CJK bracket format (auto-added foreign editions)', () => {
       const result = SeriesDetector.extractSeriesInfo('葬送のフリーレン 9 [Sōsō no Frieren 9]');
 
-      expect(result.seriesName).toBe('Sōsō no Frieren');
-      expect(result.bookNumber).toBe(9);
+      expect(result.seriesName).toBeNull();
+      expect(result.bookNumber).toBeUndefined();
     });
 
-    it('should extract series info from Japanese bracket format with multi-digit number', () => {
+    it('should skip series tracking for CJK bracket format with multi-digit number', () => {
       const result = SeriesDetector.extractSeriesInfo('葬送のフリーレン 15 [Sōsō no Frieren 15]');
 
-      expect(result.seriesName).toBe('Sōsō no Frieren');
-      expect(result.bookNumber).toBe(15);
+      expect(result.seriesName).toBeNull();
+      expect(result.bookNumber).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
## Summary

GoodReads auto-adds foreign-language editions when a user adds the English translation. These CJK-titled entries previously created duplicate series and incorrect 5x weights on JP volumes the user may not be able to read.

### Changes

**Skip CJK editions from series tracking:**
- `SeriesDetector` Pattern 6: CJK + bracket → `seriesName: null` (treated as standalone, not tracked)
- `SeriesProgressionTimelineService` Pass 2 (unnumbered inference): CJK-titled books excluded
- `SeriesProgressionTimelineService` Pass 4 (gap-fill inference): CJK-titled books excluded — prevents JP volumes from being inferred into gaps in the English series timeline

**CJK read reconciliation (Pass 1.5):**
- When a CJK bracket edition is `read` AND the same author has exactly one English `Vol.` series missing that volume number, fill it in as read
- Applies only to `read` shelf — `to-read`/`reading-next` CJK entries remain ignored to avoid phantom continuation books
- Skips ambiguous cases where an author has multiple tracked series

## Test plan

- [x] 60 tests passing
- [x] Verified against real GoodReads export — all 15 Frieren English volumes detected correctly (#1-8 read, #9 reading-next, #10-15 to-read), vol 10 gets 5x weight

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)