### PR TITLE
docs: update CLAUDE.md with mandatory pr workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,18 +87,19 @@ Every change goes through a PR. No exceptions, including small fixes.
 # 1. Create issue
 gh issue create --title "..." --label "bug"
 
-# 2. Create + checkout branch from issue
+# 2. Ensure you're on dev, then create + checkout branch from issue
+git checkout dev && git pull origin dev
 gh issue develop <N> --checkout
 
 # 3. Verify branch before EVERY commit
 git branch --show-current   # must NOT be main or dev
 
-# 4. Commit, push, open PR
+# 4. Commit, push, open PR targeting dev
 git push -u origin <branch>
-gh pr create --base main
+gh pr create --base dev
 ```
 
-**Never commit directly to `main` or `dev`.** If accidentally on main, stash changes and create a branch first.
+**Branches always come from `dev`. PRs always target `dev`.** The sync workflow promotes `dev` → `main` after release. Never commit directly to `main` or `dev`. If accidentally on main/dev, stash changes and create a branch first.
 
 ## What NOT to do
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 TypeScript Electron/CLI app that weights GoodReads to-read books based on series continuation analysis, then exports to Google Sheets for a book selection wheel.
 
-**Current version:** 1.3.2  
+**Current version:** 1.3.9  
 **Package manager:** pnpm  
 **Runtime:** Node 18+, Electron (GUI mode)
 
@@ -79,8 +79,30 @@ pnpm run build:executable  # standalone binary
 - `token.json` — OAuth token cached after first auth (writable path logic in pathResolver.ts)
 - `sheet-id.txt` — persisted Google Sheet ID
 
+## Git Workflow — MANDATORY
+
+Every change goes through a PR. No exceptions, including small fixes.
+
+```bash
+# 1. Create issue
+gh issue create --title "..." --label "bug"
+
+# 2. Create + checkout branch from issue
+gh issue develop <N> --checkout
+
+# 3. Verify branch before EVERY commit
+git branch --show-current   # must NOT be main or dev
+
+# 4. Commit, push, open PR
+git push -u origin <branch>
+gh pr create --base main
+```
+
+**Never commit directly to `main` or `dev`.** If accidentally on main, stash changes and create a branch first.
+
 ## What NOT to do
 
+- Don't commit directly to `main` or `dev` — always use a feature branch + PR
 - Don't edit `.js` test/fixture files directly — they're compiled outputs; edit `.ts` sources
 - Don't skip husky hooks (`--no-verify`) — fix the underlying lint/commit-format issue
 - Don't add weights beyond 5x/1x without updating `BookWeightingService` tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ Every change goes through a PR. No exceptions, including small fixes.
 # 1. Create issue
 gh issue create --title "..." --label "bug"
 
-# 2. Ensure you're on dev, then create + checkout branch from issue
+# 2. Branch from dev
 git checkout dev && git pull origin dev
 gh issue develop <N> --checkout
 
@@ -99,7 +99,12 @@ git push -u origin <branch>
 gh pr create --base dev
 ```
 
-**Branches always come from `dev`. PRs always target `dev`.** The sync workflow promotes `dev` → `main` after release. Never commit directly to `main` or `dev`. If accidentally on main/dev, stash changes and create a branch first.
+### Flow
+- **Feature work:** branch off `dev` → PR to `dev` → CI runs → merge
+- **Release:** PR `dev` → `main` → semantic-release creates release
+- **Sync:** `sync-main-to-dev` workflow runs automatically after release
+
+**Never commit directly to `main` or `dev`.** Branches always from `dev`. PRs always target `dev`.
 
 ## What NOT to do
 


### PR DESCRIPTION
## Summary

- Documents the mandatory git workflow: issue → branch → commit → PR, never directly to main/dev
- Adds `git branch --show-current` check step before every commit
- Updates version to 1.3.9
- Triggered by: a commit was accidentally pushed directly to main during session 2026-06-04

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)