### PR TITLE
chore: sync main into dev (resolve conflicts from #75)

### DIFF
--- a/.github/workflows/sync-main-to-dev.yml
+++ b/.github/workflows/sync-main-to-dev.yml
@@ -142,48 +142,46 @@ jobs:
               console.log(`Could not auto-approve PR (may require manual approval): ${error.message}`);
             }
 
+      - name: Commit conflicts and push branch
+        if: steps.check_sync.outputs.sync_needed == 'true' && steps.check_merge.outputs.has_conflicts == 'true'
+        run: |
+          git add -A
+          git commit -m "chore: sync main into dev (conflicts need resolution)"
+          git push origin "${{ steps.merge.outputs.branch_name }}"
+
       - name: Create PR for conflicts
         if: steps.check_sync.outputs.sync_needed == 'true' && steps.check_merge.outputs.has_conflicts == 'true'
-        uses: peter-evans/create-pull-request@v6
+        uses: actions/github-script@v7
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          branch: ${{ steps.merge.outputs.branch_name }}
-          title: "🔄 Sync main to dev (merge conflicts detected)"
-          body: |
-            ## 🔄 Automatic Sync: main → dev
-
-            **Status:** ⚠️ Merge conflicts detected
-
-            This pull request was automatically created because there were merge conflicts when attempting to sync changes from `main` into `dev`.
-
-            ### 📋 What happened:
-
-            - Changes were pushed to `main` and release workflow completed
-            - Automatic sync to `dev` was attempted
-            - Merge conflicts were detected and require manual resolution
-
-            ### 🛠️ Next steps:
-
-            1. Review the conflicts in the files below
-            2. Resolve conflicts manually
-            3. Commit the resolved changes
-            4. Merge this PR to complete the sync
-
-            ### 📊 Sync Details:
-
-            - **Source branch:** `main`
-            - **Target branch:** `dev`
-            - **Sync branch:** `${{ steps.merge.outputs.branch_name }}`
-            - **Triggered by:** Release workflow completion
-
-            ---
-
-            *This PR was automatically created by the sync workflow. Please resolve conflicts and merge to maintain Git Flow integrity.*
-          base: dev
-          labels: |
-            sync
-            merge-conflict
-            automation
+          script: |
+            const branchName = '${{ steps.merge.outputs.branch_name }}';
+            const pr = await github.rest.pulls.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: 'chore: sync main into dev (merge conflicts detected)',
+              head: branchName,
+              base: 'dev',
+              body: [
+                '## Automatic Sync: main → dev',
+                '',
+                '**Status:** ⚠️ Merge conflicts detected',
+                '',
+                'Automatic sync found conflicts. Resolve them in this branch and merge to complete the sync.',
+                '',
+                '### Next steps',
+                '1. Check out this branch',
+                '2. Resolve conflict markers in the affected files',
+                '3. Commit and push',
+                '4. Merge this PR',
+              ].join('\n'),
+            });
+            console.log(`Created PR #${pr.data.number}`);
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.data.number,
+              labels: ['sync', 'merge-conflict', 'automation'],
+            });
 
       - name: Comment on up-to-date
         if: steps.check_sync.outputs.sync_needed == 'false'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.3.9](https://github.com/dustin-lennon/goodReadsCSVFilter/compare/v1.3.8...v1.3.9) (2026-06-05)
+
+
+### Bug Fixes
+
+* reading-next book advances active series pointer for correct weighting ([59e775e](https://github.com/dustin-lennon/goodReadsCSVFilter/commit/59e775ecf7f3653a677c14d05761e6efdc5278cd)), closes [#8](https://github.com/dustin-lennon/goodReadsCSVFilter/issues/8) [#9](https://github.com/dustin-lennon/goodReadsCSVFilter/issues/9) [#10-15](https://github.com/dustin-lennon/goodReadsCSVFilter/issues/10-15)
+
 ## [1.3.8](https://github.com/dustin-lennon/goodReadsCSVFilter/compare/v1.3.7...v1.3.8) (2026-06-05)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.3.8](https://github.com/dustin-lennon/goodReadsCSVFilter/compare/v1.3.7...v1.3.8) (2026-06-05)
+
+
+### Bug Fixes
+
+* skip cjk bracket-format titles from series tracking ([#74](https://github.com/dustin-lennon/goodReadsCSVFilter/issues/74)) ([0ccf7f1](https://github.com/dustin-lennon/goodReadsCSVFilter/commit/0ccf7f1a231af00ef197405e75be6102dcd243ce)), closes [#73](https://github.com/dustin-lennon/goodReadsCSVFilter/issues/73)
+
 ## [1.3.7](https://github.com/dustin-lennon/goodReadsCSVFilter/compare/v1.3.6...v1.3.7) (2026-06-04)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.3.7](https://github.com/dustin-lennon/goodReadsCSVFilter/compare/v1.3.6...v1.3.7) (2026-06-04)
+
+
+### Bug Fixes
+
+* replace peter-evans/create-pull-request in sync workflow ([2168051](https://github.com/dustin-lennon/goodReadsCSVFilter/commit/21680515a9e52b7a6f72708420c8080d031f12da))
+
 ## [1.3.6](https://github.com/dustin-lennon/goodReadsCSVFilter/compare/v1.3.5...v1.3.6) (2026-06-04)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goodreadscsvfilter",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "description": "Intelligent series continuation weighting for GoodReads book selection",
   "main": "dist/gui/main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goodreadscsvfilter",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "description": "Intelligent series continuation weighting for GoodReads book selection",
   "main": "dist/gui/main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goodreadscsvfilter",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "description": "Intelligent series continuation weighting for GoodReads book selection",
   "main": "dist/gui/main.js",
   "scripts": {

--- a/src/core/SeriesDetector.ts
+++ b/src/core/SeriesDetector.ts
@@ -53,9 +53,17 @@ export class SeriesDetector {
     }
 
     // Pattern 6: "Japanese Title N [Romanized Title N]" - manga with bracketed romanized titles
-    // e.g. "葬送のフリーレン 9 [Sōsō no Frieren 9]" -> series: "Sōsō no Frieren", book: 9
+    // If the title contains CJK characters, skip series tracking entirely — GoodReads
+    // auto-adds foreign-language editions that users may not be able to read, and they
+    // would otherwise pollute the timeline and weighting of the English edition.
     const pattern6 = title.match(/^.+\s+(\d+(?:\.\d+)?)\s+\[(.+?)\s+\1\]$/);
     if (pattern6) {
+      const hasCJK = /[\u3040-\u30FF\u3400-\u4DBF\u4E00-\u9FFF\uF900-\uFAFF\uFF66-\uFF9F]/.test(
+        title,
+      );
+      if (hasCJK) {
+        return { seriesName: null, bookNumber: undefined };
+      }
       return {
         seriesName: pattern6[2].trim(),
         bookNumber: parseFloat(pattern6[1]),

--- a/src/services/ActiveSeriesService.ts
+++ b/src/services/ActiveSeriesService.ts
@@ -88,6 +88,11 @@ export class ActiveSeriesService {
             currentBookNumber: seriesInfo.bookNumber,
             normalizedAuthor: SeriesDetector.normalizeAuthor(book.Author),
           });
+        } else if (seriesInfo.bookNumber > existing.currentBookNumber) {
+          // Reading-next book is further along than the last-read book — update so
+          // the weighting correctly targets the book AFTER the reading-next one
+          existing.currentBook = book.Title;
+          existing.currentBookNumber = seriesInfo.bookNumber;
         }
       }
     }

--- a/src/services/SeriesProgressionTimelineService.ts
+++ b/src/services/SeriesProgressionTimelineService.ts
@@ -113,11 +113,62 @@ export class SeriesProgressionTimelineService {
       }
     }
 
+    // Pass 1.5: CJK read reconciliation
+    // When a CJK bracket edition is "read" and the same author has exactly one English Vol.
+    // series that is missing that volume number, add it as read. Applies only to "read"
+    // shelf — to-read/reading-next CJK entries are intentionally ignored to avoid creating
+    // phantom continuation books for foreign editions the user may not be tracking.
+    const CJK_RE = /[\u3040-\u30FF\u3400-\u4DBF\u4E00-\u9FFF\uF900-\uFAFF\uFF66-\uFF9F]/;
+    const BRACKET_VOL_RE = /^.+\s+(\d+(?:\.\d+)?)\s+\[.+?\s+\1\]$/;
+
+    for (const book of allBooks) {
+      if (!CJK_RE.test(book.Title)) continue;
+      if (book['Exclusive Shelf']?.trim().toLowerCase() !== ShelfType.READ) continue;
+
+      const bracketMatch = book.Title.match(BRACKET_VOL_RE);
+      if (!bracketMatch) continue;
+
+      const volNumber = parseFloat(bracketMatch[1]);
+      const normalizedAuthor = SeriesDetector.normalizeAuthor(book.Author);
+
+      // Find all series by this author
+      const authorSeries = [...seriesMap.values()].filter(
+        (s) => s.normalizedAuthor === normalizedAuthor,
+      );
+
+      // Only reconcile when there is exactly one series — avoids guessing which
+      // series the CJK volume belongs to when an author has multiple tracked series
+      if (authorSeries.length !== 1) continue;
+
+      const series = authorSeries[0];
+
+      // Only fill if the volume is genuinely missing
+      if (series.books.some((b) => b.bookNumber === volNumber)) continue;
+
+      const dateRead = book['Date Read'] ? new Date(book['Date Read']) : undefined;
+      series.books.push({
+        title: book.Title,
+        bookNumber: volNumber,
+        status: BookProgressStatus.READ,
+        dateRead,
+        author: book.Author,
+      });
+
+      if (volNumber > series.highestBookNumber) {
+        series.highestBookNumber = volNumber;
+      }
+    }
+
     // Second pass: handle books in series without explicit numbers
     // Collect unnumbered books for each series to infer their positions
     const unnumberedBooksBySeries = new Map<string, Array<{ book: Book; seriesName: string }>>();
 
     for (const book of allBooks) {
+      // Skip CJK-titled books from unnumbered inference
+      if (CJK_RE.test(book.Title)) {
+        continue;
+      }
+
       const seriesInfo = SeriesDetector.extractSeriesInfo(book.Title);
 
       // Only process books that are in a series but don't have explicit numbers
@@ -310,6 +361,12 @@ export class SeriesProgressionTimelineService {
 
             // Must not already be in the series
             if (series.books.some((b) => b.title === book.Title)) {
+              return false;
+            }
+
+            // Skip CJK-titled books — foreign-language auto-added editions should not
+            // be inferred into an English series
+            if (CJK_RE.test(book.Title)) {
               return false;
             }
 

--- a/tests/unit/ActiveSeriesService.test.ts
+++ b/tests/unit/ActiveSeriesService.test.ts
@@ -115,14 +115,14 @@ describe('ActiveSeriesService', () => {
 
       const result = await ActiveSeriesService.detectActiveSeries('fake-path.csv');
 
-      // Should detect the currently-reading book but not duplicate the reading-next book
-      // since it belongs to the same series by the same author
+      // Should detect one series entry (no duplicate), with currentBookNumber updated
+      // to the reading-next book so that the next to-read (#3) gets weighted correctly
       expect(result).toHaveLength(1);
 
       const unholyTrinity = result[0];
       expect(unholyTrinity.seriesName).toBe('Unholy Trinity');
       expect(unholyTrinity.author).toBe('Crystal Ash');
-      expect(unholyTrinity.currentBookNumber).toBe(1); // Should track the currently-reading book
+      expect(unholyTrinity.currentBookNumber).toBe(2); // reading-next #2 advances the pointer so to-read #3 gets 5x
     });
 
     it('should ignore books without series information', async () => {

--- a/tests/unit/SeriesDetector.test.ts
+++ b/tests/unit/SeriesDetector.test.ts
@@ -75,18 +75,18 @@ describe('SeriesDetector', () => {
       expect(result.bookNumber).toBe(1);
     });
 
-    it('should extract series info from Japanese bracket format: "Title N [Romanized N]"', () => {
+    it('should skip series tracking for CJK bracket format (auto-added foreign editions)', () => {
       const result = SeriesDetector.extractSeriesInfo('葬送のフリーレン 9 [Sōsō no Frieren 9]');
 
-      expect(result.seriesName).toBe('Sōsō no Frieren');
-      expect(result.bookNumber).toBe(9);
+      expect(result.seriesName).toBeNull();
+      expect(result.bookNumber).toBeUndefined();
     });
 
-    it('should extract series info from Japanese bracket format with multi-digit number', () => {
+    it('should skip series tracking for CJK bracket format with multi-digit number', () => {
       const result = SeriesDetector.extractSeriesInfo('葬送のフリーレン 15 [Sōsō no Frieren 15]');
 
-      expect(result.seriesName).toBe('Sōsō no Frieren');
-      expect(result.bookNumber).toBe(15);
+      expect(result.seriesName).toBeNull();
+      expect(result.bookNumber).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
Resolves conflicts in PR #75 (main → dev sync).

Conflicts: `package.json` version and `CHANGELOG.md` entries.
Took `main` as the source of truth for both.

Closes #75 conflict — this PR supersedes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)