### PR TITLE
fix: release — bump build-executables actions and fix release tag input

### DIFF
--- a/.github/workflows/build-executables.yml
+++ b/.github/workflows/build-executables.yml
@@ -16,17 +16,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.release.tag_name || github.event.inputs.tag }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 'lts/*'
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Install dependencies
         run: pnpm install
@@ -40,10 +40,10 @@ jobs:
           ls -lah dist-executable/ || echo "No dist-executable directory found"
 
       - name: Upload macOS artifacts to release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: dist-executable/*.dmg
-          tag: ${{ github.event.release.tag_name || github.event.inputs.tag }}
+          tag_name: ${{ github.event.release.tag_name || github.event.inputs.tag }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: false
@@ -53,17 +53,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.release.tag_name || github.event.inputs.tag }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 'lts/*'
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Install dependencies
         run: pnpm install
@@ -81,10 +81,10 @@ jobs:
           }
 
       - name: Upload Windows artifacts to release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: dist-executable/*.exe
-          tag: ${{ github.event.release.tag_name || github.event.inputs.tag }}
+          tag_name: ${{ github.event.release.tag_name || github.event.inputs.tag }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# [1.4.0](https://github.com/dustin-lennon/goodReadsCSVFilter/compare/v1.3.11...v1.4.0) (2026-06-07)
+
+
+### Bug Fixes
+
+* stop sync-main-to-dev from aborting merge before committing conflicts ([95b7fbc](https://github.com/dustin-lennon/goodReadsCSVFilter/commit/95b7fbc32cba0fb70424670ca89029fda6c11393))
+* stop sync-main-to-dev from aborting merge before committing conflicts ([#93](https://github.com/dustin-lennon/goodReadsCSVFilter/issues/93)) ([66cd121](https://github.com/dustin-lennon/goodReadsCSVFilter/commit/66cd1219076c834d76fee54b96f8129eb4735135))
+* tighten book chat system prompts to prevent topic drift ([#89](https://github.com/dustin-lennon/goodReadsCSVFilter/issues/89)) ([019a983](https://github.com/dustin-lennon/goodReadsCSVFilter/commit/019a9831b6ed5745b4b3cd4752e32026e8423a52)), closes [#74](https://github.com/dustin-lennon/goodReadsCSVFilter/issues/74) [#73](https://github.com/dustin-lennon/goodReadsCSVFilter/issues/73)
+
+
+### Features
+
+* AI series detection, book chat/journal, multi-user Google support ([#85](https://github.com/dustin-lennon/goodReadsCSVFilter/issues/85)) ([cf7a3b6](https://github.com/dustin-lennon/goodReadsCSVFilter/commit/cf7a3b6394a9ae1658c806a3d09b49a34009bfcf)), closes [#74](https://github.com/dustin-lennon/goodReadsCSVFilter/issues/74) [#73](https://github.com/dustin-lennon/goodReadsCSVFilter/issues/73)
+
 ## [1.3.11](https://github.com/dustin-lennon/goodReadsCSVFilter/compare/v1.3.10...v1.3.11) (2026-06-06)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goodreadscsvfilter",
-  "version": "1.3.11",
+  "version": "1.4.0",
   "description": "Intelligent series continuation weighting for GoodReads book selection",
   "main": "dist/gui/main.js",
   "scripts": {


### PR DESCRIPTION
Promotes `dev` to `main` to trigger semantic-release.

**Merge with regular merge (not squash)** — preserves conventional commits for semantic-release and issue auto-close.

## Changes since v1.4.0
- fix: bump build-executables actions and fix release tag input (#97, closes #96)