### PR TITLE
feat: render markdown in AI book chat responses

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,8 +56,10 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.100.1",
     "csv-parse": "^6.1.0",
+    "dompurify": "^3.4.8",
     "google-auth-library": "^10.5.0",
     "googleapis": "^153.0.0",
+    "marked": "^18.0.5",
     "open": "^10.2.0",
     "server-destroy": "^1.0.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,12 +14,18 @@ importers:
       csv-parse:
         specifier: ^6.1.0
         version: 6.1.0
+      dompurify:
+        specifier: ^3.4.8
+        version: 3.4.8
       google-auth-library:
         specifier: ^10.5.0
         version: 10.5.0
       googleapis:
         specifier: ^153.0.0
         version: 153.0.0
+      marked:
+        specifier: ^18.0.5
+        version: 18.0.5
       open:
         specifier: ^10.2.0
         version: 10.2.0
@@ -992,6 +998,9 @@ packages:
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@types/verror@1.10.11':
     resolution: {integrity: sha512-RlDm9K7+o5stv0Co8i8ZRGxDbrTxhJtgjqjFyVh/tXQyl/rYtTKlnTvZ88oSTeYREWurwx20Js4kTuKCsFkUtg==}
 
@@ -1739,6 +1748,9 @@ packages:
     engines: {node: '>=8'}
     os: [darwin]
     hasBin: true
+
+  dompurify@3.4.8:
+    resolution: {integrity: sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==}
 
   dot-prop@5.3.0:
     resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
@@ -2956,6 +2968,11 @@ packages:
   marked@15.0.12:
     resolution: {integrity: sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==}
     engines: {node: '>= 18'}
+    hasBin: true
+
+  marked@18.0.5:
+    resolution: {integrity: sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==}
+    engines: {node: '>= 20'}
     hasBin: true
 
   matcher@3.0.0:
@@ -5441,6 +5458,9 @@ snapshots:
 
   '@types/stack-utils@2.0.3': {}
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@types/verror@1.10.11':
     optional: true
 
@@ -6382,6 +6402,10 @@ snapshots:
       smart-buffer: 4.2.0
       verror: 1.10.1
     optional: true
+
+  dompurify@3.4.8:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   dot-prop@5.3.0:
     dependencies:
@@ -7922,6 +7946,8 @@ snapshots:
       supports-hyperlinks: 3.2.0
 
   marked@15.0.12: {}
+
+  marked@18.0.5: {}
 
   matcher@3.0.0:
     dependencies:

--- a/src/gui/renderer.html
+++ b/src/gui/renderer.html
@@ -518,6 +518,32 @@
 
         .chat-message.assistant p { margin: 0 0 8px; }
         .chat-message.assistant p:last-child { margin: 0; }
+        .chat-message.assistant > *:last-child { margin-bottom: 0; }
+        .chat-message.assistant ul, .chat-message.assistant ol { margin: 0 0 8px; padding-left: 22px; }
+        .chat-message.assistant li { margin: 2px 0; }
+        .chat-message.assistant code {
+            background: rgba(0, 0, 0, 0.08);
+            border-radius: 3px;
+            padding: 1px 4px;
+            font-family: 'SF Mono', Consolas, monospace;
+            font-size: 0.9em;
+        }
+        .chat-message.assistant pre {
+            background: rgba(0, 0, 0, 0.08);
+            border-radius: 6px;
+            padding: 10px;
+            overflow-x: auto;
+            margin: 0 0 8px;
+        }
+        .chat-message.assistant pre code { background: none; padding: 0; }
+        .chat-message.assistant blockquote {
+            border-left: 3px solid #a3b1d6;
+            margin: 0 0 8px;
+            padding-left: 10px;
+            color: #5a6a8a;
+        }
+        .chat-message.assistant a { color: #4a5fc1; }
+        .chat-message.assistant strong { font-weight: 600; }
 
         .chat-input-bar {
             padding: 15px;

--- a/src/gui/renderer.js
+++ b/src/gui/renderer.js
@@ -1,4 +1,6 @@
 const { ipcRenderer } = require('electron');
+const { marked } = require('marked');
+const DOMPurify = require('dompurify');
 
 class BookWeightingGUI {
   constructor() {
@@ -198,17 +200,9 @@ class BookWeightingGUI {
     div.className = `chat-message ${msg.role}`;
 
     if (msg.role === 'assistant') {
-      // Use DOM methods — never innerHTML with unsanitized content (XSS prevention)
-      const paragraphs = msg.content.split(/\n\n+/).filter(Boolean);
-      paragraphs.forEach((p) => {
-        const pEl = document.createElement('p');
-        const lines = p.split('\n');
-        lines.forEach((line, idx) => {
-          if (idx > 0) pEl.appendChild(document.createElement('br'));
-          pEl.appendChild(document.createTextNode(line));
-        });
-        div.appendChild(pEl);
-      });
+      // Render markdown, then sanitize before inserting (XSS prevention)
+      const html = marked.parse(msg.content, { breaks: true });
+      div.innerHTML = DOMPurify.sanitize(html);
     } else {
       div.textContent = msg.content;
     }


### PR DESCRIPTION
Closes #105

Assistant chat messages were rendered as plain text with naive paragraph/line splitting — markdown syntax (bold, lists, code blocks, links) showed up as raw asterisks/backticks.

## Changes
- Parse assistant message content with `marked`, sanitize the resulting HTML with `DOMPurify`, then insert into the DOM.
- Add CSS for rendered lists, code, blockquotes, links, bold within `.chat-message.assistant`.

## Security
Sanitization preserves the existing XSS-safety guarantee. Verified `<script>` and `onerror`-handler payloads are stripped before insertion (tested via marked → DOMPurify pipeline against a JSDOM window).

## Test plan
- [x] `pnpm test` — 60/60 passing
- [x] `pnpm run lint` — clean
- [x] `pnpm run typecheck` — clean
- [x] Verified markdown→sanitized-HTML pipeline against XSS payloads