### PR TITLE
docs: explain macOS Gatekeeper warning for unsigned DMG releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,15 @@ pnpm run build:executable
 
 > 📖 **See [USAGE.md](./USAGE.md) for detailed instructions on all three options**
 
+> ⚠️ **macOS: "App is damaged and can't be opened"**
+> The released `.dmg` is not code-signed/notarized (no Apple Developer ID), so macOS
+> Gatekeeper quarantines it after download and shows this misleading message. To fix,
+> after copying the app to `/Applications`, run:
+> ```bash
+> xattr -cr "/Applications/GoodReads Book Weighting System.app"
+> ```
+> Then open the app normally (or right-click → Open on first launch).
+
 ### Setup
 
 1. **Google Sheets API Setup**:


### PR DESCRIPTION
Closes #109

Released DMGs aren't code-signed/notarized, so macOS quarantines them on download and Gatekeeper shows "App is damaged and can't be opened" — a misleading message that means "unsigned", not corrupted.

Adds a README note with the `xattr -cr` workaround so users aren't blocked.

(Proper fix is codesign + notarization, which needs an active Apple Developer Program membership — out of scope.)