### PR TITLE
feat: add typing indicator while waiting for AI Book Chat response

### DIFF
--- a/src/gui/renderer.html
+++ b/src/gui/renderer.html
@@ -545,6 +545,26 @@
         .chat-message.assistant a { color: #4a5fc1; }
         .chat-message.assistant strong { font-weight: 600; }
 
+        .typing-indicator {
+            display: flex;
+            align-items: center;
+            gap: 4px;
+            padding: 14px 16px;
+        }
+        .typing-indicator span {
+            width: 8px;
+            height: 8px;
+            border-radius: 50%;
+            background: #8c9bc7;
+            animation: typing-bounce 1.2s infinite ease-in-out;
+        }
+        .typing-indicator span:nth-child(2) { animation-delay: 0.2s; }
+        .typing-indicator span:nth-child(3) { animation-delay: 0.4s; }
+        @keyframes typing-bounce {
+            0%, 60%, 100% { transform: translateY(0); opacity: 0.5; }
+            30% { transform: translateY(-6px); opacity: 1; }
+        }
+
         .chat-input-bar {
             padding: 15px;
             border-top: 1px solid #e9ecef;

--- a/src/gui/renderer.js
+++ b/src/gui/renderer.js
@@ -116,9 +116,11 @@ class BookWeightingGUI {
     const sendBtn = document.getElementById('sendMessageBtn');
     sendBtn.disabled = true;
     sendBtn.textContent = '...';
+    this.showTypingIndicator();
 
     const response = await ipcRenderer.invoke('send-chat-message', this.activeEntryId, msg);
 
+    this.hideTypingIndicator();
     sendBtn.disabled = false;
     sendBtn.textContent = 'Send';
 
@@ -209,6 +211,20 @@ class BookWeightingGUI {
 
     messagesEl.appendChild(div);
     messagesEl.scrollTop = messagesEl.scrollHeight;
+  }
+
+  showTypingIndicator() {
+    const messagesEl = document.getElementById('chatMessages');
+    const div = document.createElement('div');
+    div.className = 'chat-message assistant typing-indicator';
+    div.id = 'chatTypingIndicator';
+    div.innerHTML = '<span></span><span></span><span></span>';
+    messagesEl.appendChild(div);
+    messagesEl.scrollTop = messagesEl.scrollHeight;
+  }
+
+  hideTypingIndicator() {
+    document.getElementById('chatTypingIndicator')?.remove();
   }
 
   showChatStartForm() {


### PR DESCRIPTION
## Summary
- Adds an animated bouncing-dots "typing" indicator to the Book Chat thread while waiting for Claude's response
- Indicator appears right after the user's message is sent, removed when the assistant's reply lands
- Send button stays disabled during the wait (existing behavior)

Closes #119

## Test plan
- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `pnpm test` (60/60 passing)
- [ ] Manual: send a message in Book Chat, confirm bouncing-dots indicator shows in-thread and disappears once the reply arrives

🤖 Generated with [Claude Code](https://claude.com/claude-code)