### PR TITLE
fix: center main window content and size window to fit without scrolling

### DIFF
--- a/src/gui/main.ts
+++ b/src/gui/main.ts
@@ -34,7 +34,7 @@ class ElectronApp {
   private createWindow(): void {
     this.mainWindow = new BrowserWindow({
       width: 1000,
-      height: 700,
+      height: 940,
       webPreferences: {
         nodeIntegration: true,
         contextIsolation: false,

--- a/src/gui/renderer.html
+++ b/src/gui/renderer.html
@@ -11,7 +11,12 @@
             padding: 20px;
             background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
             color: #333;
-            min-height: 100vh;
+            height: 100vh;
+            box-sizing: border-box;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            overflow: hidden;
         }
 
         .container {


### PR DESCRIPTION
## Summary
- Centers `.container` both vertically and horizontally in the window via flexbox on `body`
- Sets `body` to `height: 100vh; overflow: hidden` to eliminate the sliver scrollbar caused by 20px padding pushing content past viewport height
- Bumps default `BrowserWindow` height 700 → 940 so the Book Processing tab's 3 steps fit on first launch without resizing or scrolling

Closes #123

## Test plan
- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `pnpm test`
- [ ] Manual: rebuild and launch GUI, confirm content is centered and no scrollbar appears on first load

🤖 Generated with [Claude Code](https://claude.com/claude-code)