### PR TITLE
fix: restore scrolling for content taller than the window

### DIFF
--- a/src/gui/renderer.html
+++ b/src/gui/renderer.html
@@ -11,12 +11,12 @@
             padding: 20px;
             background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
             color: #333;
-            height: 100vh;
+            min-height: 100vh;
             box-sizing: border-box;
             display: flex;
             align-items: center;
             justify-content: center;
-            overflow: hidden;
+            overflow-y: auto;
         }
 
         .container {


### PR DESCRIPTION
## Summary
- PR #124 set `body { height: 100vh; overflow: hidden }` to remove a sliver scrollbar — but that clipped content taller than the viewport (e.g. the Results & Export step's high-priority books list), with no way to scroll to it
- Switches to `body { min-height: 100vh; overflow-y: auto }` — keeps the centered layout, restores scrolling for tall content

Closes #127

## Test plan
- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `pnpm test`
- [ ] Manual: rebuild, run a CSV through processing, confirm the Results & Export step's high-priority books list scrolls fully into view

🤖 Generated with [Claude Code](https://claude.com/claude-code)