### PR TITLE
fix: force --no-ff merge in sync-main-to-dev to avoid [skip ci] head commit

### DIFF
--- a/.github/workflows/sync-main-to-dev.yml
+++ b/.github/workflows/sync-main-to-dev.yml
@@ -64,8 +64,11 @@ jobs:
           git checkout -b "$BRANCH_NAME"
           
           # Attempt to merge main into dev (back merge strategy)
+          # --no-ff forces a real merge commit so the PR head is never the
+          # release commit verbatim — that commit's "[skip ci]" message would
+          # otherwise cause GitHub to skip the required lint-test check entirely.
           set +e
-          git merge origin/main --no-edit
+          git merge origin/main --no-edit --no-ff
           merge_exit_code=$?
           set -e
           echo "merge_exit_code=$merge_exit_code" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
- True root cause of the always-stuck sync PRs: \`git merge --no-edit\` fast-forwards (dev is always exactly behind main by the release commit), so the sync branch HEAD becomes the release commit verbatim — \`chore(release): x.y.z [skip ci]\`
- GitHub skips **all** \`pull_request\`/\`push\` workflow runs when the head commit message contains \`[skip ci]\`, so the required \`lint-test\` check never ran and the PR sat \`BLOCKED\` forever (#126, #122, #132, #136 — all needed manual admin-merges)
- Adds \`--no-ff\` to the merge so a real merge commit (clean message) becomes the PR head, letting \`pull_request\` workflows trigger normally
- Builds on #134 (PAT swap), which is still required since GITHUB_TOKEN-created PRs never trigger \`pull_request\` workflows regardless of commit message

Closes #137

## Test plan
- [x] \`pnpm lint\` and \`pnpm test\` pass locally
- [ ] Manual: watch the next post-release \`sync-main-to-dev\` run — confirm the sync branch's HEAD is a merge commit (not \`[skip ci]\`), \`lint-test\` runs on the PR, and it auto-merges without manual intervention