### PR TITLE
fix: render markdown and preserve newlines in Book Chat user messages

### DIFF
--- a/src/gui/renderer.html
+++ b/src/gui/renderer.html
@@ -514,6 +514,27 @@
             border-bottom-right-radius: 4px;
         }
 
+        .chat-message.user p { margin: 0 0 8px; }
+        .chat-message.user p:last-child { margin: 0; }
+        .chat-message.user > *:last-child { margin-bottom: 0; }
+        .chat-message.user ul, .chat-message.user ol { margin: 0 0 8px; padding-left: 22px; }
+        .chat-message.user li { margin: 2px 0; }
+        .chat-message.user code {
+            background: rgba(255, 255, 255, 0.2);
+            padding: 1px 5px;
+            border-radius: 4px;
+            font-size: 0.9em;
+        }
+        .chat-message.user pre {
+            background: rgba(255, 255, 255, 0.15);
+            padding: 8px 10px;
+            border-radius: 6px;
+            overflow-x: auto;
+        }
+        .chat-message.user pre code { background: none; padding: 0; }
+        .chat-message.user a { color: #e0e6ff; }
+        .chat-message.user strong { font-weight: 600; }
+
         .chat-message.assistant {
             align-self: flex-start;
             background: #f0f4ff;

--- a/src/gui/renderer.js
+++ b/src/gui/renderer.js
@@ -201,13 +201,9 @@ class BookWeightingGUI {
     const div = document.createElement('div');
     div.className = `chat-message ${msg.role}`;
 
-    if (msg.role === 'assistant') {
-      // Render markdown, then sanitize before inserting (XSS prevention)
-      const html = marked.parse(msg.content, { breaks: true });
-      div.innerHTML = DOMPurify.sanitize(html);
-    } else {
-      div.textContent = msg.content;
-    }
+    // Render markdown, then sanitize before inserting (XSS prevention)
+    const html = marked.parse(msg.content, { breaks: true });
+    div.innerHTML = DOMPurify.sanitize(html);
 
     messagesEl.appendChild(div);
     messagesEl.scrollTop = messagesEl.scrollHeight;


### PR DESCRIPTION
## Summary
- User messages in Book Chat used \`div.textContent\`, so newlines collapsed visually (no \`white-space\` rule on \`.chat-message.user\`) and markdown syntax rendered as raw text
- Routes user messages through the same \`marked.parse(..., { breaks: true })\` + \`DOMPurify.sanitize\` pipeline already used for assistant messages — \`breaks: true\` turns \`\n\` into \`<br>\`, fixing both the newline and markdown issues together without weakening the existing XSS sanitization
- Added \`.chat-message.user\` style overrides for \`code\`/\`pre\`/\`a\`/\`strong\`/lists so rendered markdown reads well against the gradient bubble background

Closes #141

## Test plan
- [x] \`pnpm lint\` and \`pnpm test\` pass locally
- [ ] Manual: launch GUI, send a multi-line message with markdown (e.g. \`**bold**\`, a list, multiple lines) in Book Chat, confirm it renders formatted and preserves line breaks