### PR TITLE
fix: file dialog opens behind window and stale CSV cache after Process Another File

### DIFF
--- a/src/gui/main.ts
+++ b/src/gui/main.ts
@@ -4,6 +4,7 @@ import { BookWeightingApp } from '../core/BookWeightingApp';
 import { SeriesProgressionTimelineService } from '../services/SeriesProgressionTimelineService';
 import { AppSettingsService } from '../services/AppSettingsService';
 import { BookChatService } from '../services/BookChatService';
+import { GoodreadsCSVService } from '../services/GoodreadsCSVService';
 
 class ElectronApp {
   private mainWindow: BrowserWindow | null = null;
@@ -74,6 +75,7 @@ class ElectronApp {
     ipcMain.handle('select-csv-file', async () => {
       if (!this.mainWindow) return null;
 
+      this.mainWindow.focus();
       const { canceled, filePaths } = await dialog.showOpenDialog(this.mainWindow, {
         title: 'Select GoodReads CSV File',
         properties: ['openFile'],
@@ -85,6 +87,11 @@ class ElectronApp {
       }
 
       return filePaths[0];
+    });
+
+    // Clear CSV cache so re-processing the same file reads fresh data from disk
+    ipcMain.handle('clear-csv-cache', () => {
+      GoodreadsCSVService.clearCache();
     });
 
     // Handle book weighting process

--- a/src/gui/renderer.js
+++ b/src/gui/renderer.js
@@ -538,6 +538,9 @@ class BookWeightingGUI {
   }
 
   resetToStart() {
+    // Clear CSV cache so re-selecting the same file re-reads from disk
+    ipcRenderer.invoke('clear-csv-cache').catch(() => {});
+
     // Reset state
     this.selectedFilePath = null;
     this.results = null;


### PR DESCRIPTION
## Summary
Two bugs on the "Process Another File" flow:

**Bug 1 — File dialog opens behind window (macOS)**
After clicking "Process Another File" then "Choose CSV File", `dialog.showOpenDialog` opened behind the Electron main window, making it appear as if file selection did nothing. Fixed with `mainWindow.focus()` before the dialog call.

**Bug 2 — Stale CSV cache**
`GoodreadsCSVService` caches parsed CSV data per file path for the process lifetime. Re-selecting the same externally-edited file returned the old cached result without re-reading from disk. `resetToStart()` now calls a new `clear-csv-cache` IPC handler → `GoodreadsCSVService.clearCache()` so the next run always reads fresh.

Closes #145

## Test plan
- [x] `pnpm lint` and `pnpm test` pass locally
- [ ] Manual: run GUI, process CSV, click "Process Another File" → confirm file picker appears in front (not behind window)
- [ ] Manual: edit CSV externally, click "Process Another File", re-select same file → confirm updated data shown (not stale)