### PR TITLE
release: v1.7.7

### DIFF
--- a/.github/workflows/build-executables.yml
+++ b/.github/workflows/build-executables.yml
@@ -10,6 +10,9 @@ on:
         required: true
         type: string
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build-macos:
     runs-on: macos-latest

--- a/build-executable.js
+++ b/build-executable.js
@@ -81,14 +81,19 @@ buildGuiProcess.on('close', (guiCode) => {
     }
     
     console.log('\n🔨 Building executable with electron-builder...');
-    // Use shell: true to ensure pnpm is found in PATH (especially on Windows in CI)
-    const buildProcess = spawn('pnpm', ['exec', 'electron-builder', '--publish', 'never'], {
+    // Build to a system temp dir (APFS) to avoid ExFAT asar integrity failures.
+    // Artifacts are copied to dist-executable/ after a successful build.
+    const tmpBuildDir = require('os').tmpdir() + '/goodreads-build';
+    const buildProcess = spawn('pnpm', [
+        'exec', 'electron-builder', '--publish', 'never',
+        `--config.directories.output=${tmpBuildDir}`
+    ], {
         stdio: 'inherit',
         cwd: process.cwd(),
         shell: true
     });
     
-    handleBuildProcess(buildProcess);
+    handleBuildProcess(buildProcess, tmpBuildDir);
 });
 
 buildGuiProcess.on('error', (err) => {
@@ -97,16 +102,28 @@ buildGuiProcess.on('error', (err) => {
     process.exit(1);
 });
 
-function handleBuildProcess(buildProcess) {
+function handleBuildProcess(buildProcess, tmpBuildDir) {
 
     buildProcess.on('close', (code) => {
         if (code === 0) {
+            // Copy artifacts from temp dir to dist-executable/
+            const distPath = path.join(process.cwd(), 'dist-executable');
+            if (!fs.existsSync(distPath)) fs.mkdirSync(distPath, { recursive: true });
+            if (tmpBuildDir && fs.existsSync(tmpBuildDir)) {
+                const tmpFiles = fs.readdirSync(tmpBuildDir);
+                tmpFiles
+                    .filter(f => f.endsWith('.dmg') || f.endsWith('.dmg.blockmap') ||
+                                 f.endsWith('.exe') || f.endsWith('.AppImage') ||
+                                 f === 'latest-mac.yml' || f === 'latest.yml' ||
+                                 f === 'builder-debug.yml' || f === 'builder-effective-config.yaml')
+                    .forEach(f => fs.copyFileSync(path.join(tmpBuildDir, f), path.join(distPath, f)));
+            }
+
             console.log('\n✅ Build successful!');
             console.log('\n📂 Executable created in:');
             console.log('   ./dist-executable/');
-            
+
             // List created files and verify versions
-            const distPath = path.join(process.cwd(), 'dist-executable');
             if (fs.existsSync(distPath)) {
                 const files = fs.readdirSync(distPath);
                 const executables = files.filter(f => f.endsWith('.dmg') || f.endsWith('.exe') || f.endsWith('.AppImage'));


### PR DESCRIPTION
## Release

Merges `dev` into `main` to trigger semantic-release.

### Changes since v1.7.6

- `fix: redirect electron-builder output to APFS temp dir on ExFAT volumes` — fixes asar integrity crash when project lives on ExFAT

🤖 Generated with [Claude Code](https://claude.com/claude-code)