### PR TITLE
fix: filter stale versioned artifacts when copying from temp build dir

### DIFF
--- a/build-executable.js
+++ b/build-executable.js
@@ -111,11 +111,14 @@ function handleBuildProcess(buildProcess, tmpBuildDir) {
             if (!fs.existsSync(distPath)) fs.mkdirSync(distPath, { recursive: true });
             if (tmpBuildDir && fs.existsSync(tmpBuildDir)) {
                 const tmpFiles = fs.readdirSync(tmpBuildDir);
+                const versionedExts = ['.dmg', '.dmg.blockmap', '.exe', '.AppImage'];
+                const unversionedFiles = ['latest-mac.yml', 'latest.yml', 'builder-debug.yml', 'builder-effective-config.yaml'];
                 tmpFiles
-                    .filter(f => f.endsWith('.dmg') || f.endsWith('.dmg.blockmap') ||
-                                 f.endsWith('.exe') || f.endsWith('.AppImage') ||
-                                 f === 'latest-mac.yml' || f === 'latest.yml' ||
-                                 f === 'builder-debug.yml' || f === 'builder-effective-config.yaml')
+                    .filter(f => {
+                        if (unversionedFiles.includes(f)) return true;
+                        const isVersionedArtifact = versionedExts.some(ext => f.endsWith(ext));
+                        return isVersionedArtifact && (!currentVersion || f.includes(currentVersion));
+                    })
                     .forEach(f => fs.copyFileSync(path.join(tmpBuildDir, f), path.join(distPath, f)));
             }
 


### PR DESCRIPTION
## Summary
- Build cleanup removes old-version DMGs from `dist-executable/` at start
- But post-build copy step blindly copied ALL versioned artifacts from APFS temp dir, including stale files from prior runs — old version reappeared alongside the new one
- Fix: only copy versioned artifacts (`.dmg`, `.exe`, `.AppImage`, `.blockmap`) that include the current version string; unversioned yml/config files copy unconditionally

## Test plan
- [ ] Run `pnpm run build:executable` twice in a row — second run should show only one DMG version in "Created executables"

Closes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)